### PR TITLE
賃貸物件アプリケーションのエラー修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@
 
 # Ignore Byebug command history file.
 .byebug_history
+
+node_modules
+vendor/bundle

--- a/app/assets/javascripts/properties.coffee
+++ b/app/assets/javascripts/properties.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/properties.scss
+++ b/app/assets/stylesheets/properties.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the properties controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/assets/stylesheets/scaffolds.scss
+++ b/app/assets/stylesheets/scaffolds.scss
@@ -1,0 +1,84 @@
+body {
+  background-color: #fff;
+  color: #333;
+  margin: 33px;
+  font-family: verdana, arial, helvetica, sans-serif;
+  font-size: 13px;
+  line-height: 18px;
+}
+
+p, ol, ul, td {
+  font-family: verdana, arial, helvetica, sans-serif;
+  font-size: 13px;
+  line-height: 18px;
+}
+
+pre {
+  background-color: #eee;
+  padding: 10px;
+  font-size: 11px;
+}
+
+a {
+  color: #000;
+
+  &:visited {
+    color: #666;
+  }
+
+  &:hover {
+    color: #fff;
+    background-color: #000;
+  }
+}
+
+th {
+  padding-bottom: 5px;
+}
+
+td {
+  padding: 0 5px 7px;
+}
+
+div {
+  &.field, &.actions {
+    margin-bottom: 10px;
+  }
+}
+
+#notice {
+  color: green;
+}
+
+.field_with_errors {
+  padding: 2px;
+  background-color: red;
+  display: table;
+}
+
+#error_explanation {
+  width: 450px;
+  border: 2px solid red;
+  padding: 7px 7px 0;
+  margin-bottom: 20px;
+  background-color: #f0f0f0;
+
+  h2 {
+    text-align: left;
+    font-weight: bold;
+    padding: 5px 5px 5px 15px;
+    font-size: 12px;
+    margin: -7px -7px 0;
+    background-color: #c00;
+    color: #fff;
+  }
+
+  ul li {
+    font-size: 12px;
+    list-style: square;
+  }
+}
+
+label {
+  display: block;
+}

--- a/app/controllers/properties_controller.rb
+++ b/app/controllers/properties_controller.rb
@@ -25,8 +25,8 @@ class PropertiesController < ApplicationController
 
   # POST /properties or /properties.json
   def create
+    @n=0
     @property = Property.new(property_params)
-
     respond_to do |format|
       if @property.save
         format.html { redirect_to @property, notice: "Property was successfully created." }

--- a/app/controllers/properties_controller.rb
+++ b/app/controllers/properties_controller.rb
@@ -11,6 +11,7 @@ class PropertiesController < ApplicationController
     @n =0
     @near_station_list = Property.find(params[:id]).near_stations.first.id
     @near_station_count = Property.find(params[:id]).near_stations.count
+    @station_id_list =Property.find(params[:id]).near_stations.pluck(:id)
   end
 
   # GET /properties/new

--- a/app/controllers/properties_controller.rb
+++ b/app/controllers/properties_controller.rb
@@ -10,6 +10,7 @@ class PropertiesController < ApplicationController
   def show
     @n =0
     @near_station_list = Property.find(params[:id]).near_stations.first.id
+    @near_station_count = Property.find(params[:id]).near_stations.count
   end
 
   # GET /properties/new
@@ -21,6 +22,9 @@ class PropertiesController < ApplicationController
 
   # GET /properties/1/edit
   def edit
+    @n =0
+    @property_edit_new = Property.new
+    1.times {@property.near_stations.build}
   end
 
   # POST /properties or /properties.json

--- a/app/controllers/properties_controller.rb
+++ b/app/controllers/properties_controller.rb
@@ -1,0 +1,76 @@
+class PropertiesController < ApplicationController
+  before_action :set_property,:set_near_station, only: %i[ show edit update destroy ]
+
+  # GET /properties or /properties.json
+  def index
+    @properties = Property.all
+  end
+
+  # GET /properties/1 or /properties/1.json
+  def show
+    @n =0
+    @near_station_list = Property.find(params[:id]).near_stations.first.id
+  end
+
+  # GET /properties/new
+  def new
+    @n=0
+    @property = Property.new
+    2.times {@property.near_stations.build}
+  end
+
+  # GET /properties/1/edit
+  def edit
+  end
+
+  # POST /properties or /properties.json
+  def create
+    @property = Property.new(property_params)
+
+    respond_to do |format|
+      if @property.save
+        format.html { redirect_to @property, notice: "Property was successfully created." }
+        format.json { render :show, status: :created, location: @property }
+      else
+        format.html { render :new, status: :unprocessable_entity }
+        format.json { render json: @property.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # PATCH/PUT /properties/1 or /properties/1.json
+  def update
+    respond_to do |format|
+      if @property.update(property_params)
+        format.html { redirect_to @property, notice: "Property was successfully updated." }
+        format.json { render :show, status: :ok, location: @property }
+      else
+        format.html { render :edit, status: :unprocessable_entity }
+        format.json { render json: @property.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  # DELETE /properties/1 or /properties/1.json
+  def destroy
+    @property.destroy
+    respond_to do |format|
+      format.html { redirect_to properties_url, notice: "Property was successfully destroyed." }
+      format.json { head :no_content }
+    end
+  end
+
+  private
+    # Use callbacks to share common setup or constraints between actions.
+  def set_property
+    @property = Property.find(params[:id])
+  end
+  def set_near_station
+    @station = Property.find(params[:id]).near_stations
+  end
+    # Only allow a list of trusted parameters through.
+  def property_params
+    params.require(:property).permit(:name, :rent, :adress, :build_year, :note,
+                      near_stations_attributes:[:id,:line_name,:station_name,:lead_time])
+  end
+end

--- a/app/helpers/properties_helper.rb
+++ b/app/helpers/properties_helper.rb
@@ -1,0 +1,2 @@
+module PropertiesHelper
+end

--- a/app/models/near_station.rb
+++ b/app/models/near_station.rb
@@ -1,6 +1,3 @@
 class NearStation < ApplicationRecord
   belongs_to:property
-  validates:line_name, presence:true
-  validates:station_name, presence:true
-  validates:lead_time, presence:true,numericality: true
 end

--- a/app/models/near_station.rb
+++ b/app/models/near_station.rb
@@ -1,3 +1,6 @@
 class NearStation < ApplicationRecord
   belongs_to:property
+  validates:line_name, presence:true
+  validates:station_name, presence:true
+  validates:lead_time, presence:true,numericality: true
 end

--- a/app/models/near_station.rb
+++ b/app/models/near_station.rb
@@ -1,0 +1,3 @@
+class NearStation < ApplicationRecord
+  belongs_to:property
+end

--- a/app/models/property.rb
+++ b/app/models/property.rb
@@ -1,0 +1,4 @@
+class Property < ApplicationRecord
+  has_many:near_stations
+  accepts_nested_attributes_for:near_stations
+end

--- a/app/models/property.rb
+++ b/app/models/property.rb
@@ -1,4 +1,9 @@
 class Property < ApplicationRecord
   has_many:near_stations
   accepts_nested_attributes_for:near_stations
+  validates :name, presence:true
+  validates :rent, presence:true,numericality: true
+  validates :adress, presence:true
+  validates :build_year, presence:true,numericality: true
+  validates :note, presence:true
 end

--- a/app/models/property.rb
+++ b/app/models/property.rb
@@ -5,5 +5,4 @@ class Property < ApplicationRecord
   validates :rent, presence:true,numericality: true
   validates :adress, presence:true
   validates :build_year, presence:true,numericality: true
-  validates :note, presence:true
 end

--- a/app/views/properties/_form.html.erb
+++ b/app/views/properties/_form.html.erb
@@ -1,0 +1,63 @@
+  <%= form_with(model: property, local: true) do |form| %>
+    <% if property.errors.any? %>
+      <div id="error_explanation">
+        <h2><%= pluralize(property.errors.count, "error") %> prohibited this property from being saved:</h2>
+
+        <ul>
+        <% property.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+        </ul>
+      </div>
+    <% end %>
+
+    <div class="field">
+      <%= form.label :物件名 %>
+      <%= form.text_field :name %>
+    </div>
+
+    <div class="field">
+      <%= form.label :賃料 %>
+      <%= form.text_field :rent %>
+    </div>
+
+    <div class="field">
+      <%= form.label :住所 %>
+      <%= form.text_area :adress %>
+    </div>
+
+    <div class="field">
+      <%= form.label :築年数 %>
+      <%= form.text_field :build_year %>
+    </div>
+
+    <div class="field">
+      <%= form.label :備考 %>
+      <%= form.text_area :note %>
+    </div>
+    ---------------------------------------------------------------
+      <%= form.fields_for :near_stations do |ns| %>
+        <% @n= @n+1 %>
+        <div class="form_group">
+          <h1>最寄り駅 <%= @n %></h1>
+          <div class="field">
+            <%= ns.label :路線名 %>
+            <%= ns.text_field :line_name %>
+          </div>
+
+          <div class="field">
+            <%= ns.label :駅名 %>
+            <%= ns.text_field :station_name %>
+          </div>
+
+          <div class="field">
+            <%= ns.label :徒歩分数 %>
+            <%= ns.text_field :lead_time %>
+          </div>
+        </div>
+      <% end %>
+
+    <div class="actions">
+    <%= form.submit %>
+    </div>
+  <% end %>

--- a/app/views/properties/_form.html.erb
+++ b/app/views/properties/_form.html.erb
@@ -18,7 +18,7 @@
 
     <div class="field">
       <%= form.label :賃料 %>
-      <%= form.text_field :rent %>
+      <%= form.text_field :rent %>万円
     </div>
 
     <div class="field">
@@ -28,7 +28,7 @@
 
     <div class="field">
       <%= form.label :築年数 %>
-      <%= form.text_field :build_year %>
+      <%= form.text_field :build_year %>年
     </div>
 
     <div class="field">
@@ -52,7 +52,7 @@
 
           <div class="field">
             <%= ns.label :徒歩分数 %>
-            <%= ns.text_field :lead_time %>
+            <%= ns.text_field :lead_time %>分
           </div>
         </div>
       <% end %>

--- a/app/views/properties/_property.json.jbuilder
+++ b/app/views/properties/_property.json.jbuilder
@@ -1,0 +1,2 @@
+json.extract! property, :id, :name, :rent, :adress, :build_year, :note, :created_at, :updated_at
+json.url property_url(property, format: :json)

--- a/app/views/properties/edit.html.erb
+++ b/app/views/properties/edit.html.erb
@@ -1,0 +1,6 @@
+<h1>物件編集</h1>
+
+<%= render 'form', property: @property %>
+
+<%= link_to '詳細', @property %> |
+<%= link_to '戻る', properties_path %>

--- a/app/views/properties/index.html.erb
+++ b/app/views/properties/index.html.erb
@@ -1,0 +1,35 @@
+<p id="notice"><%= notice %></p>
+
+<h1>物件一覧</h1>
+
+<table>
+  <thead>
+    <tr>
+      <th>物件名</th>
+      <th>賃料</th>
+      <th>住所</th>
+      <th>築年数</th>
+      <th>備考</th>
+      <th colspan="3"></th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @properties.each do |property| %>
+      <tr>
+        <td><%= property.name %></td>
+        <td><%= property.rent %></td>
+        <td><%= property.adress %></td>
+        <td><%= property.build_year %></td>
+        <td><%= property.note %></td>
+        <td><%= link_to '詳細', property %></td>
+        <td><%= link_to '編集', edit_property_path(property) %></td>
+        <td><%= link_to '削除', property, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<br>
+
+<%= link_to '物件を登録する', new_property_path %>

--- a/app/views/properties/index.json.jbuilder
+++ b/app/views/properties/index.json.jbuilder
@@ -1,0 +1,1 @@
+json.array! @properties, partial: "properties/property", as: :property

--- a/app/views/properties/new.html.erb
+++ b/app/views/properties/new.html.erb
@@ -1,0 +1,5 @@
+<h1>物件登録</h1>
+
+<%= render 'form', property: @property %>
+
+<%= link_to '戻る', properties_path %>

--- a/app/views/properties/show.html.erb
+++ b/app/views/properties/show.html.erb
@@ -26,22 +26,23 @@
 </p>
 --------------------------
 <% if @station.count != 0 %>
-  <% @station.each do |f| %>
-    <% if @station.find(@near_station_list+@n).line_name && @station.find(@near_station_list+@n).station_name != "" %>
+  <% @station_id_list.each do |f| %>
+    <% if @station.find(f).line_name && @station.find(f).station_name != "" %>
       <h2>最寄り駅<%= @n+1 %></h2>
       <p>
         <strong>路線名:</strong>
-        <%= @station.find(@near_station_list+@n).line_name %>
+        <%= @station.find(f).line_name %>
       </p>
 
       <p>
         <strong>駅名:</strong>
-        <%= @station.find(@near_station_list+@n).station_name %>
+        <%= @station.find(f).station_name %>
       </p>
 
       <p>
         <strong>徒歩分数:</strong>
-        <%= @station.find(@near_station_list+@n).lead_time %>分
+        <%= @station.find(f).lead_time %>分
+
       </p>
     <% end %>
     <% @n=@n+1 %>

--- a/app/views/properties/show.html.erb
+++ b/app/views/properties/show.html.erb
@@ -1,0 +1,52 @@
+<p id="notice"><%= notice %></p>
+
+<p>
+  <strong>物件名:</strong>
+  <%= @property.name %>
+</p>
+
+<p>
+  <strong>賃料:</strong>
+  <%= @property.rent %>
+</p>
+
+<p>
+  <strong>住所:</strong>
+  <%= @property.adress %>
+</p>
+
+<p>
+  <strong>築年数:</strong>
+  <%= @property.build_year %>
+</p>
+
+<p>
+  <strong>備考:</strong>
+  <%= @property.note %>
+</p>
+--------------------------
+<% if @property.near_stations.count != 0 %>
+  <% @property.near_stations.each do |f| %>
+    <h2>最寄り駅<%= @n+1 %></h2>
+    <p>
+      <strong>路線名:</strong>
+      <%= @station.find(@near_station_list+@n).line_name %>
+    </p>
+
+    <p>
+      <strong>駅名:</strong>
+      <%= @station.find(@near_station_list+@n).station_name %>
+    </p>
+
+    <p>
+      <strong>徒歩分数:</strong>
+      <%= @station.find(@near_station_list+@n).lead_time %>
+      <% @n=@n+1 %>
+    </p>
+  <% end %>
+<% else %>
+  <p>最寄り駅の情報がありません！</p>
+<% end %>
+
+<%= link_to '編集', edit_property_path(@property) %> |
+<%= link_to '戻る', properties_path %>

--- a/app/views/properties/show.html.erb
+++ b/app/views/properties/show.html.erb
@@ -7,7 +7,7 @@
 
 <p>
   <strong>賃料:</strong>
-  <%= @property.rent %>
+  <%= @property.rent %>万円
 </p>
 
 <p>
@@ -17,7 +17,7 @@
 
 <p>
   <strong>築年数:</strong>
-  <%= @property.build_year %>
+  築<%= @property.build_year %>年
 </p>
 
 <p>
@@ -40,7 +40,7 @@
 
     <p>
       <strong>徒歩分数:</strong>
-      <%= @station.find(@near_station_list+@n).lead_time %>
+      <%= @station.find(@near_station_list+@n).lead_time %>分
       <% @n=@n+1 %>
     </p>
   <% end %>

--- a/app/views/properties/show.html.erb
+++ b/app/views/properties/show.html.erb
@@ -25,28 +25,32 @@
   <%= @property.note %>
 </p>
 --------------------------
-<% if @property.near_stations.count != 0 %>
-  <% @property.near_stations.each do |f| %>
-    <h2>最寄り駅<%= @n+1 %></h2>
-    <p>
-      <strong>路線名:</strong>
-      <%= @station.find(@near_station_list+@n).line_name %>
-    </p>
+<% if @station.count != 0 %>
+  <% @station.each do |f| %>
+    <% if @station.find(@near_station_list+@n).line_name && @station.find(@near_station_list+@n).station_name != "" %>
+      <h2>最寄り駅<%= @n+1 %></h2>
+      <p>
+        <strong>路線名:</strong>
+        <%= @station.find(@near_station_list+@n).line_name %>
+      </p>
 
-    <p>
-      <strong>駅名:</strong>
-      <%= @station.find(@near_station_list+@n).station_name %>
-    </p>
+      <p>
+        <strong>駅名:</strong>
+        <%= @station.find(@near_station_list+@n).station_name %>
+      </p>
 
-    <p>
-      <strong>徒歩分数:</strong>
-      <%= @station.find(@near_station_list+@n).lead_time %>分
-      <% @n=@n+1 %>
-    </p>
+      <p>
+        <strong>徒歩分数:</strong>
+        <%= @station.find(@near_station_list+@n).lead_time %>分
+      </p>
+    <% end %>
+    <% @n=@n+1 %>
   <% end %>
 <% else %>
   <p>最寄り駅の情報がありません！</p>
 <% end %>
 
-<%= link_to '編集', edit_property_path(@property) %> |
-<%= link_to '戻る', properties_path %>
+<div>
+  <%= link_to '編集', edit_property_path(@property) %> |
+  <%= link_to '戻る', properties_path %>
+</div>

--- a/app/views/properties/show.json.jbuilder
+++ b/app/views/properties/show.json.jbuilder
@@ -1,0 +1,1 @@
+json.partial! "properties/property", property: @property

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,4 @@
 Rails.application.routes.draw do
+  resources :properties
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end

--- a/db/migrate/20211019031517_create_properties.rb
+++ b/db/migrate/20211019031517_create_properties.rb
@@ -1,0 +1,13 @@
+class CreateProperties < ActiveRecord::Migration[5.2]
+  def change
+    create_table :properties do |t|
+      t.string :name
+      t.integer :rent
+      t.text :adress
+      t.integer :build_year
+      t.text :note
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20211019032930_create_near_stations.rb
+++ b/db/migrate/20211019032930_create_near_stations.rb
@@ -1,0 +1,10 @@
+class CreateNearStations < ActiveRecord::Migration[5.2]
+  def change
+    create_table :near_stations do |t|
+      t.string:line_name
+      t.string:station_name
+      t.integer:lead_time
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20211019033946_add_property_ref_to_near_stations.rb
+++ b/db/migrate/20211019033946_add_property_ref_to_near_stations.rb
@@ -1,0 +1,5 @@
+class AddPropertyRefToNearStations < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :near_stations, :property, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,35 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# Note that this schema.rb definition is the authoritative source for your
+# database schema. If you need to create the application database on another
+# system, you should be using db:schema:load, not running all the migrations
+# from scratch. The latter is a flawed and unsustainable approach (the more migrations
+# you'll amass, the slower it'll run and the greater likelihood for issues).
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 2021_10_19_033946) do
+
+  create_table "near_stations", force: :cascade do |t|
+    t.string "line_name"
+    t.string "station_name"
+    t.integer "lead_time"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.integer "property_id"
+    t.index ["property_id"], name: "index_near_stations_on_property_id"
+  end
+
+  create_table "properties", force: :cascade do |t|
+    t.string "name"
+    t.integer "rent"
+    t.text "adress"
+    t.integer "build_year"
+    t.text "note"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+end

--- a/test/controllers/properties_controller_test.rb
+++ b/test/controllers/properties_controller_test.rb
@@ -1,0 +1,48 @@
+require 'test_helper'
+
+class PropertiesControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @property = properties(:one)
+  end
+
+  test "should get index" do
+    get properties_url
+    assert_response :success
+  end
+
+  test "should get new" do
+    get new_property_url
+    assert_response :success
+  end
+
+  test "should create property" do
+    assert_difference('Property.count') do
+      post properties_url, params: { property: { adress: @property.adress, build_year: @property.build_year, name: @property.name, note: @property.note, rent: @property.rent } }
+    end
+
+    assert_redirected_to property_url(Property.last)
+  end
+
+  test "should show property" do
+    get property_url(@property)
+    assert_response :success
+  end
+
+  test "should get edit" do
+    get edit_property_url(@property)
+    assert_response :success
+  end
+
+  test "should update property" do
+    patch property_url(@property), params: { property: { adress: @property.adress, build_year: @property.build_year, name: @property.name, note: @property.note, rent: @property.rent } }
+    assert_redirected_to property_url(@property)
+  end
+
+  test "should destroy property" do
+    assert_difference('Property.count', -1) do
+      delete property_url(@property)
+    end
+
+    assert_redirected_to properties_url
+  end
+end

--- a/test/fixtures/near_stations.yml
+++ b/test/fixtures/near_stations.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/fixtures/properties.yml
+++ b/test/fixtures/properties.yml
@@ -1,0 +1,15 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  name: MyString
+  rent: 1
+  adress: MyText
+  build_year: 1
+  note: MyText
+
+two:
+  name: MyString
+  rent: 1
+  adress: MyText
+  build_year: 1
+  note: MyText

--- a/test/models/near_station_test.rb
+++ b/test/models/near_station_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class NearStationTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/property_test.rb
+++ b/test/models/property_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class PropertyTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/system/properties_test.rb
+++ b/test/system/properties_test.rb
@@ -1,0 +1,51 @@
+require "application_system_test_case"
+
+class PropertiesTest < ApplicationSystemTestCase
+  setup do
+    @property = properties(:one)
+  end
+
+  test "visiting the index" do
+    visit properties_url
+    assert_selector "h1", text: "Properties"
+  end
+
+  test "creating a Property" do
+    visit properties_url
+    click_on "New Property"
+
+    fill_in "Adress", with: @property.adress
+    fill_in "Build year", with: @property.build_year
+    fill_in "Name", with: @property.name
+    fill_in "Note", with: @property.note
+    fill_in "Rent", with: @property.rent
+    click_on "Create Property"
+
+    assert_text "Property was successfully created"
+    click_on "Back"
+  end
+
+  test "updating a Property" do
+    visit properties_url
+    click_on "Edit", match: :first
+
+    fill_in "Adress", with: @property.adress
+    fill_in "Build year", with: @property.build_year
+    fill_in "Name", with: @property.name
+    fill_in "Note", with: @property.note
+    fill_in "Rent", with: @property.rent
+    click_on "Update Property"
+
+    assert_text "Property was successfully updated"
+    click_on "Back"
+  end
+
+  test "destroying a Property" do
+    visit properties_url
+    page.accept_confirm do
+      click_on "Destroy", match: :first
+    end
+
+    assert_text "Property was successfully destroyed"
+  end
+end


### PR DESCRIPTION
-  最寄駅がゼロの場合、もしくは1つしかない物件も登録できること
-編集画面では、あらたにひとつの最寄駅を登録できる入力欄を表示させること。これにより、最寄駅の登録数が増えても対応できるようにすること。

上の２点の解決